### PR TITLE
use compiler to ensure interface is implemented

### DIFF
--- a/cyclonedx/cyclonedx_test.go
+++ b/cyclonedx/cyclonedx_test.go
@@ -262,3 +262,6 @@ func setupCycloneDX(t *testing.T) *CycloneDX {
 	logger, _ := test.NewNullLogger()
 	return Default(logger)
 }
+
+// use compiler to ensure ICycloneDX interface is implemented by CycloneDX
+var _ ICycloneDX = (*CycloneDX)(nil)

--- a/iq/iq_test.go
+++ b/iq/iq_test.go
@@ -213,3 +213,6 @@ func setupIQServer(t *testing.T) *Server {
 	logger, _ := test.NewNullLogger()
 	return New(logger, setupIqOptions())
 }
+
+// use compiler to ensure IServer interface is implemented by Server
+var _ IServer = (*Server)(nil)

--- a/ossindex/ossindex_test.go
+++ b/ossindex/ossindex_test.go
@@ -257,3 +257,6 @@ func setupJSON(t *testing.T) (coordJSON []byte, err error) {
 
 	return
 }
+
+// use compiler to ensure IServer interface is implemented by Server
+var _ IServer = (*Server)(nil)

--- a/useragent/useragent_test.go
+++ b/useragent/useragent_test.go
@@ -193,3 +193,6 @@ func setupUserAgent(t *testing.T) *Agent {
 	}
 	return New(logger, options)
 }
+
+// use compiler to ensure IAgent interface is implemented by Agent
+var _ IAgent = (*Agent)(nil)


### PR DESCRIPTION
simple code to ensure interfaces are actually implemented. compiler will detect method signature divergence, and flag farcical implementation.