### PR TITLE
notify caller via error if partial credentials are provided

### DIFF
--- a/ossindex/ossindex.go
+++ b/ossindex/ossindex.go
@@ -164,6 +164,9 @@ func (o *Server) doRequestToOSSIndex(jsonStr []byte) (coordinates []types.Coordi
 	return
 }
 
+const msgMissingOssiToken = "missing ossi token"
+const msgMissingOssiUsername = "missing ossi username"
+
 func (o *Server) setupRequest(jsonStr []byte) (req *http.Request, err error) {
 	o.logLady.WithField("json_string", string(jsonStr)).Debug("Setting up new POST request to OSS Index")
 	req, err = http.NewRequest(
@@ -181,7 +184,13 @@ func (o *Server) setupRequest(jsonStr []byte) (req *http.Request, err error) {
 	o.logLady.WithField("user_agent", ua).Debug("Obtained User Agent for request to OSS Index")
 
 	req.Header.Set("Content-Type", "application/json")
-	if o.Options.Username != "" && o.Options.Token != "" {
+	if o.Options.Username != "" || o.Options.Token != "" {
+		switch {
+		case o.Options.Token == "":
+			return nil, fmt.Errorf(msgMissingOssiToken)
+		case o.Options.Username == "":
+			return nil, fmt.Errorf(msgMissingOssiUsername)
+		}
 		o.logLady.Info("Set OSS Index Basic Auth")
 		req.SetBasicAuth(o.Options.Username, o.Options.Token)
 	}

--- a/ossindex/ossindex_test.go
+++ b/ossindex/ossindex_test.go
@@ -19,6 +19,7 @@ package ossindex
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -266,6 +267,19 @@ func TestSetupRequest(t *testing.T) {
 	assert.Equal(t, token, "test")
 	assert.Equal(t, ok, true)
 	assert.Nil(t, err)
+}
+
+func TestSetupRequestMissingCredentials(t *testing.T) {
+	coordJSON, _ := setupJSON(t)
+	ossindex := setupOSSIndex(t)
+	ossindex.Options.Token = ""
+	_, err := ossindex.setupRequest(coordJSON)
+	assert.Equal(t, fmt.Errorf(msgMissingOssiToken), err)
+
+	ossindex.Options.Token = "myToken"
+	ossindex.Options.Username = ""
+	_, err = ossindex.setupRequest(coordJSON)
+	assert.Equal(t, fmt.Errorf(msgMissingOssiUsername), err)
 }
 
 // TODO: Use this for more than just TestSetupRequest


### PR DESCRIPTION
The existing behavior is confusing from the client perspective (e.g. nancy) when partial credentials are provided (e.g. only username or only token), the call to ossi goes through, but only does so because the partial credentials were silently ignored.

This PR detects if some, but not all credentials are missing, and notifies the caller what is missing (username or token).