### PR TITLE
Handle trailing slash when setting up IQ Server

### DIFF
--- a/iq/iq.go
+++ b/iq/iq.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -166,6 +167,10 @@ func New(logger *logrus.Logger, options Options) (server *Server, err error) {
 	if options.TTL.IsZero() {
 		logger.Trace("Setting TTL to 12 hours since it wasn't set explicitly")
 		options.TTL = time.Now().Local().Add(time.Hour * 12)
+	}
+
+	if strings.HasSuffix(options.Server, "/") {
+		options.Server = strings.TrimSuffix(options.Server, "/")
 	}
 
 	ua := useragent.New(logger, useragent.Options{ClientTool: options.Tool, Version: options.Version})

--- a/iq/iq_test.go
+++ b/iq/iq_test.go
@@ -20,11 +20,12 @@ package iq
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/sonatype-nexus-community/go-sona-types/ossindex"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/sonatype-nexus-community/go-sona-types/ossindex"
 
 	"github.com/jarcoal/httpmock"
 	"github.com/sirupsen/logrus/hooks/test"
@@ -75,7 +76,7 @@ func setupIqOptions() (options Options) {
 	return
 }
 
-func TestNewRequiredOptions(t *testing.T) {
+func TestNewRequiredAndModifiedOptions(t *testing.T) {
 	server, err := New(nil, Options{})
 	assert.Equal(t, fmt.Errorf("missing logger"), err)
 	assert.Nil(t, server)
@@ -100,6 +101,11 @@ func TestNewRequiredOptions(t *testing.T) {
 	server, err = New(logger, Options{Application: "myAppId", Server: "myServer", User: "myUser", Token: "myToken"})
 	assert.NotNil(t, server)
 	assert.Nil(t, err)
+
+	server, err = New(logger, Options{Application: "myAppId", Server: "myServer/", User: "myUser", Token: "myToken"})
+	assert.NotNil(t, server)
+	assert.Nil(t, err)
+	assert.Equal(t, server.Options.Server, "myServer")
 }
 
 func TestAuditPackages(t *testing.T) {


### PR DESCRIPTION
Basically, if someone provides a trailing Slash for the server address when creating an IQ Server instance, let's trim that if it exists.

Related to: https://github.com/sonatype-nexus-community/nancy/issues/196