### PR TITLE
Allow for Audit using []packageurl.PackageURL

### DIFF
--- a/cyclonedx/cyclonedx.go
+++ b/cyclonedx/cyclonedx.go
@@ -239,9 +239,12 @@ func (c *CycloneDX) processPackageURLsAndSha1sIntoSBOMSchema1_1(results []packag
 		component := Component{
 			Type:    "library",
 			BomRef:  v.ToString(),
-			Purl:    v.ToString(),
 			Name:    v.Name,
 			Version: v.Version,
+		}
+
+		if v.Type != "pypi" {
+			component.Purl = v.ToString()
 		}
 
 		sbom.Components.Component = append(sbom.Components.Component, component)

--- a/cyclonedx/cyclonedx.go
+++ b/cyclonedx/cyclonedx.go
@@ -185,7 +185,7 @@ func (c *CycloneDX) FromPackageURLs(results []packageurl.PackageURL) string {
 // FromPackageURLsAndSha1s will take []packageurl.PackageURL and []File and convert them
 // into a minimal 1.1 CycloneDX sbom
 func (c *CycloneDX) FromPackageURLsAndSha1s(results []packageurl.PackageURL, sha1s []File) string {
-	return c.processPackageURLsIntoSBOMSchema1_1(results)
+	return c.processPackageURLsAndSha1sIntoSBOMSchema1_1(results, sha1s)
 }
 
 // FromSHA1s will take []Sha1SBOM and convert them

--- a/cyclonedx/cyclonedx.go
+++ b/cyclonedx/cyclonedx.go
@@ -135,7 +135,7 @@ const (
 type ICycloneDX interface {
 	FromCoordinates(r []types.Coordinate) string
 	FromPackageURLs(r []packageurl.PackageURL) string
-	FromPackageURLsAndSha1s(r []packageurl.PackageURL, sha1s []File)
+	FromPackageURLsAndSha1s(r []packageurl.PackageURL, sha1s []File) string
 	FromSHA1s(r []Sha1SBOM) string
 }
 

--- a/cyclonedx/cyclonedx.go
+++ b/cyclonedx/cyclonedx.go
@@ -26,7 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/sonatype-nexus-community/go-sona-types/ossindex/types"
 
-	"github.com/package-url/packageurl-go"
+	"github.com/DarthHater/packageurl-go"
 )
 
 // CycloneDX Types

--- a/cyclonedx/cyclonedx.go
+++ b/cyclonedx/cyclonedx.go
@@ -135,7 +135,7 @@ const (
 type ICycloneDX interface {
 	FromCoordinates(r []types.Coordinate) string
 	FromPackageURLs(r []packageurl.PackageURL) string
-	FromPackageURLAndSha1s(r []packageurl.PackageURL, sha1s []File)
+	FromPackageURLsAndSha1s(r []packageurl.PackageURL, sha1s []File)
 	FromSHA1s(r []Sha1SBOM) string
 }
 

--- a/cyclonedx/cyclonedx.go
+++ b/cyclonedx/cyclonedx.go
@@ -243,9 +243,7 @@ func (c *CycloneDX) processPackageURLsAndSha1sIntoSBOMSchema1_1(results []packag
 			Version: v.Version,
 		}
 
-		if v.Type != "pypi" {
-			component.Purl = v.ToString()
-		}
+		component.Purl = v.ToString()
 
 		sbom.Components.Component = append(sbom.Components.Component, component)
 	}

--- a/cyclonedx/cyclonedx_test.go
+++ b/cyclonedx/cyclonedx_test.go
@@ -20,8 +20,8 @@ package cyclonedx
 import (
 	"testing"
 
+	"github.com/DarthHater/packageurl-go"
 	"github.com/beevik/etree"
-	"github.com/package-url/packageurl-go"
 	"github.com/shopspring/decimal"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/sonatype-nexus-community/go-sona-types/ossindex/types"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/sonatype-nexus-community/go-sona-types
 go 1.14
 
 require (
-	github.com/DarthHater/packageurl-go v0.1.1-0.20201020202434-0e5a2acb1446
+	github.com/DarthHater/packageurl-go v0.1.1-0.20201022013050-2ab9db397c59
 	github.com/beevik/etree v1.1.0
 	github.com/briandowns/spinner v1.11.1
 	github.com/jarcoal/httpmock v1.0.5

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,11 @@ module github.com/sonatype-nexus-community/go-sona-types
 go 1.14
 
 require (
+	github.com/DarthHater/packageurl-go v0.1.1-0.20201020202434-0e5a2acb1446
 	github.com/beevik/etree v1.1.0
+	github.com/briandowns/spinner v1.11.1
 	github.com/jarcoal/httpmock v1.0.5
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
-	github.com/package-url/packageurl-go v0.1.0
 	github.com/recoilme/pudge v1.0.3
 	github.com/shopspring/decimal v1.2.0
 	github.com/sirupsen/logrus v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,14 @@
+github.com/DarthHater/packageurl-go v0.1.1-0.20201020202434-0e5a2acb1446 h1:3x8UJQ7X4ncci6D+bAWpoT5gmQgIoL5EzWOTtSZYYIo=
+github.com/DarthHater/packageurl-go v0.1.1-0.20201020202434-0e5a2acb1446/go.mod h1:/FxmOTaQ5RifcIAsSQwhXw6wOBmSi3QALI9b0M8gMnQ=
 github.com/beevik/etree v1.1.0 h1:T0xke/WvNtMoCqgzPhkX2r4rjY3GDZFi+FjpRZY2Jbs=
 github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
+github.com/briandowns/spinner v1.11.1 h1:OixPqDEcX3juo5AjQZAnFPbeUA0jvkp2qzB5gOZJ/L0=
+github.com/briandowns/spinner v1.11.1/go.mod h1:QOuQk7x+EaDASo80FEXwlwiA+j/PPIcX3FScO+3/ZPQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
+github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/jarcoal/httpmock v1.0.5 h1:cHtVEcTxRSX4J0je7mWPfc9BpDpqzXSJ5HbymZmyHck=
 github.com/jarcoal/httpmock v1.0.5/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
@@ -10,6 +16,10 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxv
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
+github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/package-url/packageurl-go v0.1.0 h1:efWBc98O/dBZRg1pw2xiDzovnlMjCa9NPnfaiBduh8I=
@@ -26,6 +36,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 h1:DYfZAGf2WMFjMxbgTjaC+2HC7NkNAQs+6Q8b9WEB/F4=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/DarthHater/packageurl-go v0.1.1-0.20201020202434-0e5a2acb1446 h1:3x8UJQ7X4ncci6D+bAWpoT5gmQgIoL5EzWOTtSZYYIo=
 github.com/DarthHater/packageurl-go v0.1.1-0.20201020202434-0e5a2acb1446/go.mod h1:/FxmOTaQ5RifcIAsSQwhXw6wOBmSi3QALI9b0M8gMnQ=
+github.com/DarthHater/packageurl-go v0.1.1-0.20201022013050-2ab9db397c59 h1:bWN4GMTxAI4v3I412SPfXJ4Zp29zk3I6kTpwV15egMU=
+github.com/DarthHater/packageurl-go v0.1.1-0.20201022013050-2ab9db397c59/go.mod h1:/FxmOTaQ5RifcIAsSQwhXw6wOBmSi3QALI9b0M8gMnQ=
 github.com/beevik/etree v1.1.0 h1:T0xke/WvNtMoCqgzPhkX2r4rjY3GDZFi+FjpRZY2Jbs=
 github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
 github.com/briandowns/spinner v1.11.1 h1:OixPqDEcX3juo5AjQZAnFPbeUA0jvkp2qzB5gOZJ/L0=

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -482,6 +482,7 @@ func (i *Server) createApplicationID(applicationID string) (appID string, err er
 
 	req.SetBasicAuth(i.Options.User, i.Options.Token)
 	req.Header.Set("User-Agent", i.agent.GetUserAgent())
+	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -534,6 +535,7 @@ func (i *Server) createApplicationID(applicationID string) (appID string, err er
 			Message: "Unable to retrieve an internal ID",
 		}
 	}
+
 	i.logLady.WithFields(logrus.Fields{
 		"status_code": resp.StatusCode,
 	}).Error("Error communicating with Nexus IQ Server application endpoint")

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -27,8 +27,8 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/DarthHater/packageurl-go"
 	"github.com/briandowns/spinner"
-	"github.com/package-url/packageurl-go"
 	"github.com/sirupsen/logrus"
 	"github.com/sonatype-nexus-community/go-sona-types/cyclonedx"
 	"github.com/sonatype-nexus-community/go-sona-types/ossindex"

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -150,6 +150,7 @@ func (i *ServerErrorMissingLicense) Error() string {
 
 // IServer is an interface that can be used for mocking the Server struct
 type IServer interface {
+	Audit(p []packageurl.PackageURL, f []cyclonedx.File) (StatusURLResult, error)
 	AuditPackages(p []string) (StatusURLResult, error)
 }
 

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -20,6 +20,7 @@ package iq
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -37,6 +38,10 @@ import (
 
 const internalApplicationIDURL = "/api/v2/applications?publicId="
 
+const createApplicationIDURL = "/api/v2/applications"
+
+const getOrganizationsURL = "/api/v2/organizations"
+
 const thirdPartyAPILeft = "/api/v2/scan/applications/"
 
 const thirdPartyAPIRight = "/sources/nancy?stageId="
@@ -47,6 +52,46 @@ type StatusURLResult struct {
 	ReportHTMLURL string `json:"reportHtmlUrl"`
 	IsError       bool   `json:"isError"`
 	ErrorMessage  string `json:"errorMessage"`
+}
+
+type organizationResult struct {
+	Organizations []struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+		Tags []tags `json:"tags"`
+	} `json:"organizations"`
+}
+
+type applicationCreation struct {
+	PublicID        string           `json:"publicId"`
+	Name            string           `json:"name"`
+	OrganizationID  string           `json:"organizationId"`
+	ContactUserName string           `json:"contactUserName"`
+	ApplicationTags []applicationTag `json:"applicationTags"`
+}
+
+type applicationCreationResponse struct {
+	ID              string `json:"id"`
+	PublicID        string `json:"publicId"`
+	Name            string `json:"name"`
+	OrganizationID  string `json:"organizationId"`
+	ContactUserName string `json:"contactUserName"`
+	ApplicationTags []struct {
+		ID            string `json:"id"`
+		TagID         string `json:"tagId"`
+		ApplicationID string `json:"applicationId"`
+	} `json:"applicationTags"`
+}
+
+type applicationTag struct {
+	TagID string `json:"tagId"`
+}
+
+type tags struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Color       string `json:"color"`
 }
 
 // Internal types for use by this package, don't need to expose them
@@ -81,6 +126,15 @@ func (i *ServerError) Error() string {
 		return fmt.Sprintf("An error occurred: %s, err: %s", i.Message, i.Err.Error())
 	}
 	return fmt.Sprintf("An error occurred: %s", i.Message)
+}
+
+// ApplicationMissingError is a custom error type that can be used to tell that a
+// response to IQ was fine, but that no Application exists with that ID
+type ApplicationIDError struct {
+}
+
+func (i *ApplicationIDError) Error() string {
+	return "No application available with that public application ID"
 }
 
 type ServerErrorMissingLicense struct {
@@ -198,7 +252,7 @@ func (i *Server) Audit(purls []packageurl.PackageURL, sha1s []cyclonedx.File) (S
 		warnUserOfBadLifeChoices()
 	}
 
-	internalID, err := i.getInternalApplicationID(i.Options.Application)
+	internalID, err := i.getOrCreateInternalApplicationID(i.Options.Application)
 	if internalID == "" && err != nil {
 		i.logLady.Error("Internal ID not obtained from Nexus IQ")
 		return statusURLResp, err
@@ -304,6 +358,186 @@ func (i *Server) getStatusURL(internalID string, sbom string) (StatusURLResult, 
 	return statusURLResp, r.err
 }
 
+func (i *Server) getOrCreateInternalApplicationID(applicationID string) (appID string, err error) {
+	appID, err = i.getInternalApplicationID(applicationID)
+	if err != nil {
+		if _, ok := err.(*ApplicationIDError); ok {
+			i.logLady.Debug("No Application ID found, attempting to create one")
+		} else {
+			return "", err
+		}
+	}
+
+	return "", nil
+}
+
+func (i *Server) getOrganizations() (organizationResult, error) {
+	client := &http.Client{}
+
+	req, err := http.NewRequest(
+		"GET",
+		fmt.Sprintf("%s%s", i.Options.Server, getOrganizationsURL),
+		nil,
+	)
+	if err != nil {
+		return organizationResult{}, &ServerError{
+			Err:     err,
+			Message: "Setup of request for getting organizations failed",
+		}
+	}
+	req.SetBasicAuth(i.Options.User, i.Options.Token)
+	req.Header.Set("User-Agent", i.agent.GetUserAgent())
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return organizationResult{}, &ServerError{
+			Err:     err,
+			Message: "There was an error communicating with Nexus IQ Server to get a list of organizations",
+		}
+	}
+
+	if resp.StatusCode == http.StatusPaymentRequired {
+		i.logLady.WithField("resp_status_code", resp.Status).Error("Error accessing Nexus IQ Server due to product license")
+		return organizationResult{}, &ServerErrorMissingLicense{}
+	}
+
+	//noinspection GoUnhandledErrorResult
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return organizationResult{}, &ServerError{
+				Err:     err,
+				Message: "There was an error retrieving the bytes of the response for getting your internal application ID from Nexus IQ Server",
+			}
+		}
+
+		var orgs organizationResult
+		err = json.Unmarshal(bodyBytes, &orgs)
+		if err != nil {
+			return organizationResult{}, &ServerError{
+				Err:     err,
+				Message: "failed to unmarshal response",
+			}
+		}
+	}
+	return organizationResult{}, &ServerError{
+		Err:     fmt.Errorf("Unable to communicate with Nexus IQ Server, status code returned is: %d", resp.StatusCode),
+		Message: "Unable to communicate with Nexus IQ Server",
+	}
+}
+
+func (i *Server) createApplicationID(applicationID string) (appID string, err error) {
+	client := &http.Client{}
+	orgs, err := i.getOrganizations()
+	if err != nil {
+		return "", err
+	}
+
+	orgID := ""
+	var tagIDs []applicationTag
+
+	if len(orgs.Organizations) > 0 {
+		orgID = orgs.Organizations[0].ID
+
+		if len(orgs.Organizations[0].Tags) > 0 {
+			for _, v := range orgs.Organizations[0].Tags {
+				tagIDs = append(tagIDs, applicationTag{TagID: v.ID})
+			}
+		}
+	} else {
+		return "", errors.New("No organization IDs found")
+	}
+
+	app := applicationCreation{
+		PublicID:        applicationID,
+		Name:            applicationID,
+		OrganizationID:  orgID,
+		ContactUserName: i.Options.User,
+		ApplicationTags: tagIDs,
+	}
+
+	js, err := json.Marshal(app)
+	if err != nil {
+		return "", errors.New("Unable to marshall json")
+	}
+
+	req, err := http.NewRequest(
+		"POST",
+		fmt.Sprintf("%s%s%s", i.Options.Server, createApplicationIDURL),
+		bytes.NewBuffer(js),
+	)
+	if err != nil {
+		return "", &ServerError{
+			Err:     err,
+			Message: "Setup of request to create internal application id failed",
+		}
+	}
+
+	req.SetBasicAuth(i.Options.User, i.Options.Token)
+	req.Header.Set("User-Agent", i.agent.GetUserAgent())
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", &ServerError{
+			Err:     err,
+			Message: "There was an error communicating with Nexus IQ Server to create your application ID",
+		}
+	}
+
+	if resp.StatusCode == http.StatusPaymentRequired {
+		i.logLady.WithField("resp_status_code", resp.Status).Error("Error accessing Nexus IQ Server due to product license")
+		return "", &ServerErrorMissingLicense{}
+	}
+
+	//noinspection GoUnhandledErrorResult
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return "", &ServerError{
+				Err:     err,
+				Message: "There was an error retrieving the bytes of the response for getting your internal application ID from Nexus IQ Server",
+			}
+		}
+
+		var response applicationCreationResponse
+		err = json.Unmarshal(bodyBytes, &response)
+		if err != nil {
+			return "", &ServerError{
+				Err:     err,
+				Message: "failed to unmarshal response",
+			}
+		}
+
+		if response.ID != "" {
+			i.logLady.WithFields(logrus.Fields{
+				"internal_id": response.ID,
+			}).Debug("Created internal ID with Nexus IQ Server")
+
+			return response.ID, nil
+		}
+
+		i.logLady.WithFields(logrus.Fields{
+			"application_id": applicationID,
+		}).Error("Unable to retrieve an internal ID for the specified public application ID")
+
+		return "", &ServerError{
+			Err:     fmt.Errorf("Unable to retrieve an internal ID for the specified public application ID: %s", applicationID),
+			Message: "Unable to retrieve an internal ID",
+		}
+	}
+	i.logLady.WithFields(logrus.Fields{
+		"status_code": resp.StatusCode,
+	}).Error("Error communicating with Nexus IQ Server application endpoint")
+	return "", &ServerError{
+		Err:     fmt.Errorf("Unable to communicate with Nexus IQ Server, status code returned is: %d", resp.StatusCode),
+		Message: "Unable to communicate with Nexus IQ Server",
+	}
+}
+
 func (i *Server) getInternalApplicationID(applicationID string) (string, error) {
 	client := &http.Client{}
 
@@ -368,10 +602,7 @@ func (i *Server) getInternalApplicationID(applicationID string) (string, error) 
 			"application_id": applicationID,
 		}).Error("Unable to retrieve an internal ID for the specified public application ID")
 
-		return "", &ServerError{
-			Err:     fmt.Errorf("Unable to retrieve an internal ID for the specified public application ID: %s", applicationID),
-			Message: "Unable to retrieve an internal ID",
-		}
+		return "", &ApplicationIDError{}
 	}
 	i.logLady.WithFields(logrus.Fields{
 		"status_code": resp.StatusCode,

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -465,7 +465,7 @@ func (i *Server) createApplicationID(applicationID string) (appID string, err er
 
 	req, err := http.NewRequest(
 		"POST",
-		fmt.Sprintf("%s%s%s", i.Options.Server, createApplicationIDURL),
+		fmt.Sprintf("%s%s", i.Options.Server, createApplicationIDURL),
 		bytes.NewBuffer(js),
 	)
 	if err != nil {

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -611,7 +611,14 @@ func (i *Server) getInternalApplicationID(applicationID string) (string, error) 
 
 		return "", &ApplicationIDError{ApplicationID: applicationID}
 	}
+	// something went wrong
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		i.logLady.Error(err)
+		// do not return to allow the ServerError below to be returned
+	}
 	i.logLady.WithFields(logrus.Fields{
+		"body":        string(bodyBytes),
 		"status_code": resp.StatusCode,
 	}).Error("Error communicating with Nexus IQ Server application endpoint")
 	return "", &ServerError{

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -603,7 +603,7 @@ func (i *Server) getInternalApplicationID(applicationID string) (string, error) 
 			"application_id": applicationID,
 		}).Error("Unable to retrieve an internal ID for the specified public application ID")
 
-		return "", &ApplicationIDError{}
+		return "", &ApplicationIDError{ApplicationID: applicationID}
 	}
 	i.logLady.WithFields(logrus.Fields{
 		"status_code": resp.StatusCode,

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -363,12 +363,12 @@ func (i *Server) getOrCreateInternalApplicationID(applicationID string) (appID s
 	if err != nil {
 		if _, ok := err.(*ApplicationIDError); ok {
 			i.logLady.Debug("No Application ID found, attempting to create one")
-		} else {
-			return "", err
+			return i.createApplicationID(applicationID)
 		}
+		return
 	}
 
-	return "", nil
+	return
 }
 
 func (i *Server) getOrganizations() (organizationResult, error) {

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -537,8 +537,14 @@ func (i *Server) createApplicationID(applicationID string) (appID string, err er
 			Message: "Unable to retrieve an internal ID",
 		}
 	}
-
+	// something went wrong
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		i.logLady.Error(err)
+		// do not return to allow the ServerError below to be returned
+	}
 	i.logLady.WithFields(logrus.Fields{
+		"body":        string(bodyBytes),
 		"status_code": resp.StatusCode,
 	}).Error("Error communicating with Nexus IQ Server application endpoint")
 	return "", &ServerError{

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -131,10 +131,11 @@ func (i *ServerError) Error() string {
 // ApplicationMissingError is a custom error type that can be used to tell that a
 // response to IQ was fine, but that no Application exists with that ID
 type ApplicationIDError struct {
+	ApplicationID string
 }
 
 func (i *ApplicationIDError) Error() string {
-	return "No application available with that public application ID"
+	return fmt.Sprint("Unable to retrieve an internal ID for the specified public application ID:", i.ApplicationID)
 }
 
 type ServerErrorMissingLicense struct {

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -135,7 +135,7 @@ type ApplicationIDError struct {
 }
 
 func (i *ApplicationIDError) Error() string {
-	return fmt.Sprint("Unable to retrieve an internal ID for the specified public application ID:", i.ApplicationID)
+	return fmt.Sprint("Unable to retrieve an internal ID for the specified public application ID: ", i.ApplicationID)
 }
 
 type ServerErrorMissingLicense struct {

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -55,8 +55,7 @@ type StatusURLResult struct {
 }
 
 type organizationResult struct {
-	Organizations []struct {
-	} `json:"organizations"`
+	Organizations []organization `json:"organizations"`
 }
 
 type organization struct {

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -446,11 +446,21 @@ func (i *Server) createApplicationID(applicationID string) (appID string, err er
 	var tagIDs []applicationTag
 
 	if len(orgs.Organizations) > 0 {
-		orgID = orgs.Organizations[0].ID
+		if orgs.Organizations[0].ID == "ROOT_ORGANIZATION_ID" {
+			orgID = orgs.Organizations[1].ID
 
-		if len(orgs.Organizations[0].Tags) > 0 {
-			for _, v := range orgs.Organizations[0].Tags {
-				tagIDs = append(tagIDs, applicationTag{TagID: v.ID})
+			if len(orgs.Organizations[1].Tags) > 0 {
+				for _, v := range orgs.Organizations[1].Tags {
+					tagIDs = append(tagIDs, applicationTag{TagID: v.ID})
+				}
+			}
+		} else {
+			orgID = orgs.Organizations[0].ID
+
+			if len(orgs.Organizations[0].Tags) > 0 {
+				for _, v := range orgs.Organizations[0].Tags {
+					tagIDs = append(tagIDs, applicationTag{TagID: v.ID})
+				}
 			}
 		}
 	} else {

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -56,10 +56,13 @@ type StatusURLResult struct {
 
 type organizationResult struct {
 	Organizations []struct {
-		ID   string `json:"id"`
-		Name string `json:"name"`
-		Tags []tags `json:"tags"`
 	} `json:"organizations"`
+}
+
+type organization struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Tags []tags `json:"tags"`
 }
 
 type applicationCreation struct {

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -397,6 +397,8 @@ func (i *Server) getOrganizations() (organizationResult, error) {
 		}
 	}
 
+	i.logLady.Debug("Got response from IQ Server for Organizations")
+
 	if resp.StatusCode == http.StatusPaymentRequired {
 		i.logLady.WithField("resp_status_code", resp.Status).Error("Error accessing Nexus IQ Server due to product license")
 		return organizationResult{}, &ServerErrorMissingLicense{}
@@ -422,6 +424,8 @@ func (i *Server) getOrganizations() (organizationResult, error) {
 				Message: "failed to unmarshal response",
 			}
 		}
+
+		return orgs, nil
 	}
 	return organizationResult{}, &ServerError{
 		Err:     fmt.Errorf("Unable to communicate with Nexus IQ Server, status code returned is: %d", resp.StatusCode),

--- a/iq/iq_test.go
+++ b/iq/iq_test.go
@@ -25,10 +25,7 @@ import (
 	"testing"
 	"time"
 
-<<<<<<< HEAD
 	"github.com/DarthHater/packageurl-go"
-=======
->>>>>>> origin/master
 	"github.com/sonatype-nexus-community/go-sona-types/ossindex"
 
 	"github.com/jarcoal/httpmock"

--- a/iq/iq_test.go
+++ b/iq/iq_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/package-url/packageurl-go"
+	"github.com/DarthHater/packageurl-go"
 	"github.com/sonatype-nexus-community/go-sona-types/ossindex"
 
 	"github.com/jarcoal/httpmock"

--- a/iq/iq_test.go
+++ b/iq/iq_test.go
@@ -173,7 +173,7 @@ func TestAudit(t *testing.T) {
 }
 
 func TestAuditPackagesIqCannotLocateApplicationID(t *testing.T) {
-	expectedError := "An error occurred: Unable to retrieve an internal ID, err: Unable to retrieve an internal ID for the specified public application ID: testapp"
+	expectedError := "Unable to retrieve an internal ID for the specified public application ID: testapp"
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 

--- a/iq/iq_test.go
+++ b/iq/iq_test.go
@@ -165,7 +165,7 @@ func TestAudit(t *testing.T) {
 
 	iq := setupIQServer(t)
 
-	result, _ := iq.Audit(purls)
+	result, _ := iq.Audit(purls, nil)
 
 	statusExpected := StatusURLResult{PolicyAction: "None", ReportHTMLURL: "http://sillyplace.com:8090/ui/links/application/test-app/report/95c4c14e", IsError: false}
 


### PR DESCRIPTION
We'd been talking about this for a little while, mostly in that the packageurl.PackageURL struct gives us easier access to say, name, version, etc... without having to write our own parsers. This comes in handy as we currently use the third party API quite a bit (which accepts an sbom with purls), but in theory allows us to use other APIs that don't handle a purl quite as easily.

Added:
- iq.Audit(purls []packageurl.PackageURL) (StatusURLResult, error)
- Test for new function
- Moved shared portions of iq.Audit and iq.AuditPackages into iq.getStatusUrl

Tests pass locally! 