### PR TITLE
Absorb `configuration` package from Nancy

### DIFF
--- a/configuration/set.go
+++ b/configuration/set.go
@@ -1,3 +1,17 @@
+// Copyright 2018-present Sonatype Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package configuration
 
 import (

--- a/configuration/set.go
+++ b/configuration/set.go
@@ -27,6 +27,9 @@ import (
 	"strings"
 )
 
+// For use when overriding Viper config type, e.g.: viper.SetConfigType(ConfigTypeYaml)
+const ConfigTypeYaml = "yaml"
+
 // these consts must match their associated yaml tag below. for use where tag name matters, like viper
 const ViperKeyUsername = "ossi.Username"
 const ViperKeyToken = "ossi.Token"

--- a/configuration/set.go
+++ b/configuration/set.go
@@ -1,0 +1,205 @@
+package configuration
+
+import (
+	"bufio"
+	"fmt"
+	"github.com/sirupsen/logrus"
+	"github.com/sonatype-nexus-community/go-sona-types/ossindex/types"
+	"gopkg.in/yaml.v2"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// these consts must match their associated yaml tag below. for use where tag name matters, like viper
+const ViperKeyUsername = "ossi.Username"
+const ViperKeyToken = "ossi.Token"
+
+// OSSIndexConfig is a struct for holding OSS Index Configuration, and for writing it to yaml
+type OSSIndexConfig struct {
+	Username string `yaml:"Username"`
+	Token    string `yaml:"Token"`
+}
+
+type ConfMarshallOssi struct {
+	Ossi OSSIndexConfig
+}
+
+// these consts must match their associated yaml tag below. for use where tag name matters, like viper
+const ViperKeyIQServer = "iq.Server"
+const ViperKeyIQUsername = "iq.Username"
+const ViperKeyIQToken = "iq.Token"
+
+// IQConfig is a struct for holding IQ Configuration, and for writing it to yaml
+type IQConfig struct {
+	IQServer   string `yaml:"Server"`
+	IQUsername string `yaml:"Username"`
+	IQToken    string `yaml:"Token"`
+}
+
+type ConfMarshallIq struct {
+	Iq IQConfig
+}
+
+type ConfigSet struct {
+	logLady *logrus.Logger
+	// HomeDir is exported so that in testing it can be set to a location like /tmp
+	HomeDir string
+	// ConfigLocation is exported so that in testing it can be used to test if the file has been written properly
+	ConfigLocation string
+}
+
+func New(logger *logrus.Logger) (configSet *ConfigSet, err error) {
+	if logger == nil {
+		err = fmt.Errorf("missing logger")
+		return
+	}
+
+	homeDir, _ := os.UserHomeDir()
+	configSet = &ConfigSet{logLady: logger, HomeDir: homeDir}
+	return
+}
+
+const msgConfigNotSet = "warning: config not set"
+
+// GetConfigFromCommandLine is a method to obtain IQ or OSS Index config from the command line,
+// and then write it to disk.
+func (i *ConfigSet) GetConfigFromCommandLine(stdin io.Reader) (err error) {
+	i.logLady.Info("Starting process to obtain config from user")
+	reader := bufio.NewReader(stdin)
+	fmt.Print("Hi! What config can I help you set, IQ or OSS Index (values: iq, ossindex, enter for exit)? ")
+	configType, _ := reader.ReadString('\n')
+
+	switch str := strings.TrimSpace(configType); str {
+	case "iq":
+		i.logLady.Info("User chose to set IQ Config, moving forward")
+		i.ConfigLocation = filepath.Join(i.HomeDir, types.IQServerDirName, types.IQServerConfigFileName)
+		err = i.getAndSetIQConfig(reader)
+	case "ossindex":
+		i.logLady.Info("User chose to set OSS Index config, moving forward")
+		i.ConfigLocation = filepath.Join(i.HomeDir, types.OssIndexDirName, types.OssIndexConfigFileName)
+		err = i.getAndSetOSSIndexConfig(reader)
+	case "":
+		return fmt.Errorf(msgConfigNotSet)
+	default:
+		i.logLady.Infof("User chose invalid config type: %s, will retry", str)
+		fmt.Printf("Invalid value: %s, 'iq' and 'ossindex' are accepted values, try again!\n", str)
+		err = i.GetConfigFromCommandLine(stdin)
+	}
+
+	if err != nil {
+		i.logLady.Error(err)
+		return
+	}
+	return
+}
+
+func (i *ConfigSet) getAndSetIQConfig(reader *bufio.Reader) (err error) {
+	i.logLady.Info("Getting config for IQ Server from user")
+
+	iqConfig := IQConfig{IQServer: "http://localhost:8070", IQUsername: "admin", IQToken: "admin123"}
+
+	fmt.Print("What is the address of your Nexus IQ Server (default: http://localhost:8070)? ")
+	server, _ := reader.ReadString('\n')
+	iqConfig.IQServer = emptyOrDefault(server, iqConfig.IQServer)
+
+	fmt.Print("What username do you want to authenticate as (default: admin)? ")
+	username, _ := reader.ReadString('\n')
+	iqConfig.IQUsername = emptyOrDefault(username, iqConfig.IQUsername)
+
+	fmt.Print("What token do you want to use (default: admin123)? ")
+	token, _ := reader.ReadString('\n')
+	iqConfig.IQToken = emptyOrDefault(token, iqConfig.IQToken)
+
+	if iqConfig.IQUsername == "admin" || iqConfig.IQToken == "admin123" {
+		i.logLady.Info("Warning user of bad life choices, using default values for IQ Server username or token")
+		warnUserOfBadLifeChoices()
+		fmt.Print("[y/N]? ")
+		theChoice, _ := reader.ReadString('\n')
+		theChoice = emptyOrDefault(theChoice, "y")
+		if theChoice == "y" {
+			i.logLady.Info("User chose to rectify their bad life choices, asking for config again")
+			err = i.getAndSetIQConfig(reader)
+		} else {
+			i.logLady.Info("Successfully got IQ Server config from user, attempting to save to disk")
+			err = i.marshallAndWriteToDisk(ConfMarshallIq{Iq: iqConfig})
+		}
+	} else {
+		i.logLady.Info("Successfully got IQ Server config from user, attempting to save to disk")
+		err = i.marshallAndWriteToDisk(ConfMarshallIq{Iq: iqConfig})
+	}
+
+	if err != nil {
+		i.logLady.Error(err)
+		return
+	}
+	return
+}
+
+func emptyOrDefault(value string, defaultValue string) string {
+	str := strings.Trim(strings.TrimSpace(value), "\n")
+	if str == "" {
+		return defaultValue
+	}
+	return str
+}
+
+func (i *ConfigSet) getAndSetOSSIndexConfig(reader *bufio.Reader) (err error) {
+	i.logLady.Info("Getting config for OSS Index from user")
+
+	ossIndexConfig := OSSIndexConfig{}
+
+	fmt.Print("What username do you want to authenticate as (ex: admin)? ")
+	ossIndexConfig.Username, _ = reader.ReadString('\n')
+	ossIndexConfig.Username = strings.Trim(strings.TrimSpace(ossIndexConfig.Username), "\n")
+
+	fmt.Print("What token do you want to use? ")
+	ossIndexConfig.Token, _ = reader.ReadString('\n')
+	ossIndexConfig.Token = strings.Trim(strings.TrimSpace(ossIndexConfig.Token), "\n")
+
+	i.logLady.Info("Successfully got OSS Index config from user, attempting to save to disk")
+	err = i.marshallAndWriteToDisk(ConfMarshallOssi{Ossi: ossIndexConfig})
+	if err != nil {
+		i.logLady.Error(err)
+		return
+	}
+
+	return
+}
+
+func (i *ConfigSet) marshallAndWriteToDisk(config interface{}) (err error) {
+	d, err := yaml.Marshal(config)
+	if err != nil {
+		return err
+	}
+
+	base := filepath.Dir(i.ConfigLocation)
+
+	if _, err = os.Stat(base); os.IsNotExist(err) {
+		err = os.Mkdir(base, os.ModePerm)
+		if err != nil {
+			return
+		}
+	}
+
+	err = ioutil.WriteFile(i.ConfigLocation, d, 0644)
+	if err != nil {
+		return
+	}
+
+	i.logLady.WithField("config_location", i.ConfigLocation).Info("Successfully wrote config to disk")
+	fmt.Printf("Successfully wrote config to: %s\n", i.ConfigLocation)
+	return
+}
+
+func warnUserOfBadLifeChoices() {
+	fmt.Println()
+	fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+	fmt.Println("!!!! WARNING : You are using the default username and/or password for Nexus IQ. !!!!")
+	fmt.Println("!!!! You are strongly encouraged to change these, and use a token.              !!!!")
+	fmt.Println("!!!! Would you like to change them and try again?                               !!!!")
+	fmt.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+	fmt.Println()
+}

--- a/configuration/set.go
+++ b/configuration/set.go
@@ -132,7 +132,7 @@ func (i *ConfigSet) getAndSetIQConfig(reader *bufio.Reader) (err error) {
 		warnUserOfBadLifeChoices()
 		fmt.Print("[y/N]? ")
 		theChoice, _ := reader.ReadString('\n')
-		theChoice = emptyOrDefault(theChoice, "y")
+		theChoice = emptyOrDefault(theChoice, "N")
 		if theChoice == "y" {
 			i.logLady.Info("User chose to rectify their bad life choices, asking for config again")
 			err = i.getAndSetIQConfig(reader)

--- a/configuration/set_test.go
+++ b/configuration/set_test.go
@@ -1,0 +1,142 @@
+package configuration
+
+import (
+	"bytes"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	"strings"
+	"testing"
+)
+
+func setup(t *testing.T) (configSet *ConfigSet) {
+	logger, _ := test.NewNullLogger()
+	configSet, err := New(logger)
+	assert.Nil(t, err)
+	configSet.HomeDir = "/tmp"
+	return
+}
+
+func TestGetConfigFromCommandLineLoggerNil(t *testing.T) {
+	badConfig, err := New(nil)
+	assert.Error(t, err)
+	assert.Equal(t, "missing logger", err.Error())
+	assert.Nil(t, badConfig)
+}
+
+var (
+	configSet *ConfigSet
+)
+
+func TestGetConfigFromCommandLineInvalidConfigType(t *testing.T) {
+	var buffer bytes.Buffer
+	buffer.Write([]byte("badconfigtype\ntestuser\ntoken\n"))
+
+	configSet = setup(t)
+	err := configSet.GetConfigFromCommandLine(&buffer)
+	assert.Error(t, err)
+	assert.Equal(t, msgConfigNotSet, err.Error())
+}
+
+func TestGetConfigFromCommandLineOssIndex(t *testing.T) {
+	var buffer bytes.Buffer
+	buffer.Write([]byte("ossindex\ntestuser\ntoken\n"))
+
+	configSet = setup(t)
+	err := configSet.GetConfigFromCommandLine(&buffer)
+	if err != nil {
+		t.Errorf("Test failed: %s", err.Error())
+	}
+
+	b, err := ioutil.ReadFile(configSet.ConfigLocation)
+	if err != nil {
+		t.Errorf("Test failed: %s", err.Error())
+	}
+
+	var confMarshallOssi ConfMarshallOssi
+	err = yaml.Unmarshal(b, &confMarshallOssi)
+	if err != nil {
+		t.Errorf("Test failed: %s", err.Error())
+	}
+
+	if confMarshallOssi.Ossi.Username != "testuser" && confMarshallOssi.Ossi.Token != "token" {
+		t.Errorf("Config not set properly, expected 'testuser' && 'token' but got '%s' and '%s'", confMarshallOssi.Ossi.Username, confMarshallOssi.Ossi.Token)
+	}
+
+	// since we have the file bytes, also verify the ViperKey strings
+	content := string(b)
+	verifyYamlLine(t, content, ViperKeyUsername, "testuser")
+	verifyYamlLine(t, content, ViperKeyToken, "token")
+}
+
+func verifyYamlLine(t *testing.T, content string, viperKey string, expectedValue string) {
+	yamlPrefix := viperKey[:strings.Index(viperKey, ".")]
+	println(yamlPrefix)
+
+	// no harm in re-testing yaml header each time
+	if !strings.HasPrefix(content, yamlPrefix+":") {
+		t.Errorf("wrong config yaml")
+	}
+
+	expectedYamlLine := "  " + strings.TrimPrefix(viperKey, yamlPrefix+".") + ": " + expectedValue
+	assert.Contains(t, content, expectedYamlLine)
+}
+
+func TestGetConfigFromCommandLineIqServer(t *testing.T) {
+	var buffer bytes.Buffer
+	buffer.Write([]byte("iq\nhttp://localhost:8070\nadmin\nadmin123\nn"))
+
+	configSet = setup(t)
+	err := configSet.GetConfigFromCommandLine(&buffer)
+	if err != nil {
+		t.Errorf("Test failed: %s", err.Error())
+	}
+
+	b, err := ioutil.ReadFile(configSet.ConfigLocation)
+	if err != nil {
+		t.Errorf("Test failed: %s", err.Error())
+	}
+
+	var confMarshallIq ConfMarshallIq
+	err = yaml.Unmarshal(b, &confMarshallIq)
+	if err != nil {
+		t.Errorf("Test failed: %s", err.Error())
+	}
+
+	if confMarshallIq.Iq.IQUsername != "admin" && confMarshallIq.Iq.IQToken != "admin123" && confMarshallIq.Iq.IQServer != "http://localhost:8070" {
+		t.Errorf("Config not set properly, expected 'admin', 'admin123' and 'http://localhost:8070' but got %s, %s and %s", confMarshallIq.Iq.IQUsername, confMarshallIq.Iq.IQToken, confMarshallIq.Iq.IQServer)
+	}
+
+	// since we have the file bytes, also verify the ViperKey strings
+	content := string(b)
+	verifyYamlLine(t, content, ViperKeyIQServer, "http://localhost:8070")
+	verifyYamlLine(t, content, ViperKeyIQUsername, "admin")
+	verifyYamlLine(t, content, ViperKeyIQToken, "admin123")
+}
+
+func TestGetConfigFromCommandLineIqServerWithLoopToResetConfig(t *testing.T) {
+	var buffer bytes.Buffer
+	buffer.Write([]byte("iq\nhttp://localhost:8070\nadmin\nadmin123\ny\nhttp://localhost:8080\nadmin1\nadmin1234\n"))
+
+	configSet = setup(t)
+	err := configSet.GetConfigFromCommandLine(&buffer)
+	if err != nil {
+		t.Errorf("Test failed: %s", err.Error())
+	}
+
+	b, err := ioutil.ReadFile(configSet.ConfigLocation)
+	if err != nil {
+		t.Errorf("Test failed: %s", err.Error())
+	}
+
+	var confMarshallIq ConfMarshallIq
+	err = yaml.Unmarshal(b, &confMarshallIq)
+	if err != nil {
+		t.Errorf("Test failed: %s", err.Error())
+	}
+
+	if confMarshallIq.Iq.IQUsername != "admin1" && confMarshallIq.Iq.IQToken != "admin1234" && confMarshallIq.Iq.IQServer != "http://localhost:8080" {
+		t.Errorf("Config not set properly, expected 'admin1', 'admin1234' and 'http://localhost:8080' but got %s, %s and %s", confMarshallIq.Iq.IQUsername, confMarshallIq.Iq.IQToken, confMarshallIq.Iq.IQServer)
+	}
+}

--- a/configuration/set_test.go
+++ b/configuration/set_test.go
@@ -129,6 +129,32 @@ func TestGetConfigFromCommandLineIqServer(t *testing.T) {
 	verifyYamlLine(t, content, ViperKeyIQToken, "admin123")
 }
 
+func TestGetConfigFromCommandLineIqServerRectifyBadChoicesDefault(t *testing.T) {
+	var buffer bytes.Buffer
+	buffer.Write([]byte("iq\nhttp://localhost:8070\nadmin\nadmin123\n\n"))
+
+	configSet = setup(t)
+	err := configSet.GetConfigFromCommandLine(&buffer)
+	if err != nil {
+		t.Errorf("Test failed: %s", err.Error())
+	}
+
+	b, err := ioutil.ReadFile(configSet.ConfigLocation)
+	if err != nil {
+		t.Errorf("Test failed: %s", err.Error())
+	}
+
+	var confMarshallIq ConfMarshallIq
+	err = yaml.Unmarshal(b, &confMarshallIq)
+	if err != nil {
+		t.Errorf("Test failed: %s", err.Error())
+	}
+
+	if confMarshallIq.Iq.IQUsername != "admin" && confMarshallIq.Iq.IQToken != "admin123" && confMarshallIq.Iq.IQServer != "http://localhost:8070" {
+		t.Errorf("Config not set properly, expected 'admin', 'admin123' and 'http://localhost:8070' but got %s, %s and %s", confMarshallIq.Iq.IQUsername, confMarshallIq.Iq.IQToken, confMarshallIq.Iq.IQServer)
+	}
+}
+
 func TestGetConfigFromCommandLineIqServerWithLoopToResetConfig(t *testing.T) {
 	var buffer bytes.Buffer
 	buffer.Write([]byte("iq\nhttp://localhost:8070\nadmin\nadmin123\ny\nhttp://localhost:8080\nadmin1\nadmin1234\n"))

--- a/configuration/set_test.go
+++ b/configuration/set_test.go
@@ -1,3 +1,17 @@
+// Copyright 2018-present Sonatype Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package configuration
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -14,5 +14,5 @@ require (
 	golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1
-	gopkg.in/yaml.v2 v2.3.0 // indirect
+	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,7 @@ gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8X
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/go-playground/assert.v1 v1.2.1 h1:xoYuJVE7KT85PYWrN730RguIQO0ePzVRfFMXadIrXTM=
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Move [configuration](https://github.com/sonatype-nexus-community/nancy/tree/main/internal/configuration) package from Nancy into go-sona-types. This will allow other go projects that use `ossi` and` iq` credentials to more easily share (and set) the same config files and file format used by Nancy.

Once this PR is merged, the related branch in Nancy, PR [g-s-t_configuration](https://github.com/sonatype-nexus-community/nancy/pull/200) will be updated to use these changes.

Also, relates to [Ahab Issue #27](https://github.com/sonatype-nexus-community/ahab/issues/27) and this [Ahab PR](https://github.com/sonatype-nexus-community/ahab/pull/54).