### PR TITLE
add AbsoluteReportHTMLURL field

### DIFF
--- a/.circleci/circleci-readme.md
+++ b/.circleci/circleci-readme.md
@@ -1,0 +1,28 @@
+CI Debug Notes
+================
+To validate some circleci stuff, I was able to run a “build locally” using the steps below.
+The local build runs in a docker container.
+
+  * (Once) Install circleci client (`brew install circleci`)
+
+  * Convert the “real” config.yml into a self contained (non-workspace) config via:
+
+        circleci config process .circleci/config.yml > .circleci/local-config.yml
+
+  * Run a local build with the following command:
+          
+        circleci local execute -c .circleci/local-config.yml --job 'build'
+
+    Typically, both commands are run together:
+    
+        circleci config process .circleci/config.yml > .circleci/local-config.yml && circleci local execute -c .circleci/local-config.yml --job 'build'
+    
+    With the above command, operations that cannot occur during a local build will show an error like this:
+     
+      ```
+      ... Error: FAILED with error not supported
+      ```
+    
+      However, the build will proceed and can complete “successfully”, which allows you to verify scripts in your config, etc.
+      
+      If the build does complete successfully, you should see a happy yellow `Success!` message.

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .cache
 .DS_Store
+
+# ci config for local ci build
+.circleci/local-config.yml

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -54,9 +54,9 @@ type StatusURLResult struct {
 type PolicyAction string
 
 const (
-	None    = "None"
-	Warning = "Warning"
-	Failure = "Failure"
+	PolicyActionNone    = "None"
+	PolicyActionWarning = "Warning"
+	PolicyActionFailure = "Failure"
 )
 
 // Internal types for use by this package, don't need to expose them

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -51,13 +51,17 @@ type StatusURLResult struct {
 }
 
 // Valid policy action values
-const PolicyActionNone = "None"
+type PolicyAction int
 
-//goland:noinspection GoUnusedConst
-const PolicyActionWarning = "Warning"
+const (
+	None PolicyAction = iota
+	Warning
+	Failure
+)
 
-//goland:noinspection GoUnusedConst
-const PolicyActionFailure = "Failure"
+func (pa PolicyAction) String() string {
+	return [...]string{"None", "Warning", "Failure"}[pa]
+}
 
 // Internal types for use by this package, don't need to expose them
 type applicationResponse struct {

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -531,7 +531,7 @@ func (i *Server) pollIQServer(statusURL string, finished chan resultError) error
 
 func (i *Server) populateAbsoluteURL() {
 	if !strings.HasPrefix(statusURLResp.ReportHTMLURL, i.Options.Server) {
-		// newer versions of IQ use relative urls
+		// newer versions of IQ (104+) use relative urls
 
 		iqServerUrl := i.Options.Server
 		// slash madness

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -458,8 +458,10 @@ func (i *Server) pollIQServer(statusURL string, finished chan resultError) error
 		"status_url":     statusURL,
 	}).Trace("Polling Nexus IQ for response")
 	if i.tries > i.Options.MaxRetries {
-		i.logLady.Error("Maximum tries exceeded, finished polling, consider bumping up Max Retries")
-		finished <- resultError{finished: true, err: nil}
+		i.logLady.WithField("retries", i.Options.MaxRetries).Error("Maximum tries exceeded, finished polling, consider bumping up Max Retries")
+		err := fmt.Errorf("exceeded max retries: %d", i.Options.MaxRetries)
+		finished <- resultError{finished: true, err: err}
+		return &ServerError{Err: err, Message: "exceeded max retries"}
 	}
 
 	client := &http.Client{}

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -50,8 +50,13 @@ type StatusURLResult struct {
 }
 
 // Valid policy action values
+//goland:noinspection GoUnusedConst
 const PolicyActionNone = "None"
+
+//goland:noinspection GoUnusedConst
 const PolicyActionWarning = "Warning"
+
+//goland:noinspection GoUnusedConst
 const PolicyActionFailure = "Failure"
 
 // Internal types for use by this package, don't need to expose them

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -51,17 +51,13 @@ type StatusURLResult struct {
 }
 
 // Valid policy action values
-type PolicyAction int
+type PolicyAction string
 
 const (
-	None PolicyAction = iota
-	Warning
-	Failure
+	None    = "None"
+	Warning = "Warning"
+	Failure = "Failure"
 )
-
-func (pa PolicyAction) String() string {
-	return [...]string{"None", "Warning", "Failure"}[pa]
-}
 
 // Internal types for use by this package, don't need to expose them
 type applicationResponse struct {

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -530,7 +530,7 @@ func (i *Server) pollIQServer(statusURL string, finished chan resultError) error
 			finished <- resultError{finished: true, err: nil}
 		}
 
-		i.populateAbsoluteURL()
+		statusURLResp.populateAbsoluteURL(i.Options.Server)
 		finished <- resultError{finished: true, err: nil}
 	}
 	i.tries++
@@ -538,19 +538,18 @@ func (i *Server) pollIQServer(statusURL string, finished chan resultError) error
 	return err
 }
 
-func (i *Server) populateAbsoluteURL() {
-	if !strings.HasPrefix(statusURLResp.ReportHTMLURL, i.Options.Server) {
+func (i *StatusURLResult) populateAbsoluteURL(iqServerBaseURL string) {
+	if !strings.HasPrefix(statusURLResp.ReportHTMLURL, iqServerBaseURL) {
 		// newer versions of IQ (104+) use relative urls
 
-		iqServerUrl := i.Options.Server
 		// slash madness
 		var pathSlash string
-		if strings.HasPrefix(statusURLResp.ReportHTMLURL, "/") || strings.HasSuffix(iqServerUrl, "/") {
+		if strings.HasPrefix(statusURLResp.ReportHTMLURL, "/") || strings.HasSuffix(iqServerBaseURL, "/") {
 			pathSlash = ""
 		} else {
 			pathSlash = "/"
 		}
-		statusURLResp.AbsoluteReportHTMLURL = iqServerUrl + pathSlash + statusURLResp.ReportHTMLURL
+		statusURLResp.AbsoluteReportHTMLURL = iqServerBaseURL + pathSlash + statusURLResp.ReportHTMLURL
 	} else {
 		statusURLResp.AbsoluteReportHTMLURL = statusURLResp.ReportHTMLURL
 	}

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -49,6 +49,11 @@ type StatusURLResult struct {
 	ErrorMessage          string `json:"errorMessage"`
 }
 
+// Valid policy action values
+const PolicyActionNone = "None"
+const PolicyActionWarning = "Warning"
+const PolicyActionFailure = "Failure"
+
 // Internal types for use by this package, don't need to expose them
 type applicationResponse struct {
 	Applications []application `json:"applications"`

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -51,8 +51,6 @@ type StatusURLResult struct {
 }
 
 // Valid policy action values
-type PolicyAction string
-
 const (
 	PolicyActionNone    = "None"
 	PolicyActionWarning = "Warning"

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -50,7 +50,6 @@ type StatusURLResult struct {
 }
 
 // Valid policy action values
-//goland:noinspection GoUnusedConst
 const PolicyActionNone = "None"
 
 //goland:noinspection GoUnusedConst

--- a/iq/iq_test.go
+++ b/iq/iq_test.go
@@ -160,30 +160,30 @@ func Test_populateAbsoluteURL(t *testing.T) {
 	iq := setupIQServer(t)
 
 	// defaults, just for completeness
-	iq.populateAbsoluteURL()
+	statusURLResp.populateAbsoluteURL(iq.Options.Server)
 	assert.Equal(t, "http://sillyplace.com:8090/", statusURLResp.AbsoluteReportHTMLURL)
 
 	// slash prefix on relative url
 	statusURLResp.ReportHTMLURL = "/myReport"
-	iq.populateAbsoluteURL()
+	statusURLResp.populateAbsoluteURL(iq.Options.Server)
 	assert.Equal(t, "http://sillyplace.com:8090/myReport", statusURLResp.AbsoluteReportHTMLURL)
 
 	// slash suffix on server url
 	iq.Options.Server = "http://sillyplace.com:8090/"
 	statusURLResp.ReportHTMLURL = "myReport"
-	iq.populateAbsoluteURL()
+	statusURLResp.populateAbsoluteURL(iq.Options.Server)
 	assert.Equal(t, "http://sillyplace.com:8090/myReport", statusURLResp.AbsoluteReportHTMLURL)
 
 	// slashes everywhere - we don't avoid double slash-ery
 	iq.Options.Server = "http://sillyplace.com:8090/"
 	statusURLResp.ReportHTMLURL = "/myReport"
-	iq.populateAbsoluteURL()
+	statusURLResp.populateAbsoluteURL(iq.Options.Server)
 	assert.Equal(t, "http://sillyplace.com:8090//myReport", statusURLResp.AbsoluteReportHTMLURL)
 
 	// no slashes anywhere
 	iq.Options.Server = "http://sillyplace.com:8090"
 	statusURLResp.ReportHTMLURL = "myReport"
-	iq.populateAbsoluteURL()
+	statusURLResp.populateAbsoluteURL(iq.Options.Server)
 	assert.Equal(t, "http://sillyplace.com:8090/myReport", statusURLResp.AbsoluteReportHTMLURL)
 }
 

--- a/iq/iq_test.go
+++ b/iq/iq_test.go
@@ -242,7 +242,7 @@ func TestAuditPackages(t *testing.T) {
 
 	result, _ := iq.AuditPackages(purls)
 
-	statusExpected := StatusURLResult{PolicyAction: PolicyActionNone,
+	statusExpected := StatusURLResult{PolicyAction: None.String(),
 		ReportHTMLURL:         "http://sillyplace.com:8090/ui/links/application/test-app/report/95c4c14e",
 		AbsoluteReportHTMLURL: "http://sillyplace.com:8090/ui/links/application/test-app/report/95c4c14e",
 	}
@@ -287,7 +287,7 @@ func TestAuditPackagesRelativeResult(t *testing.T) {
 
 	result, _ := iq.AuditPackages(purls)
 
-	statusExpected := StatusURLResult{PolicyAction: PolicyActionNone,
+	statusExpected := StatusURLResult{PolicyAction: None.String(),
 		ReportHTMLURL:         "ui/links/application/test-app/report/95c4c14e",
 		AbsoluteReportHTMLURL: "http://sillyplace.com:8090/ui/links/application/test-app/report/95c4c14e",
 	}
@@ -324,7 +324,7 @@ func TestAuditPackagesWithSBOM(t *testing.T) {
 
 	result, _ := iq.AuditWithSbom(sbom)
 
-	statusExpected := StatusURLResult{PolicyAction: PolicyActionNone,
+	statusExpected := StatusURLResult{PolicyAction: None.String(),
 		ReportHTMLURL:         "http://sillyplace.com:8090/ui/links/application/test-app/report/95c4c14e",
 		AbsoluteReportHTMLURL: "http://sillyplace.com:8090/ui/links/application/test-app/report/95c4c14e",
 	}
@@ -545,6 +545,12 @@ func TestAuditPackagesIqUpButBadThirdPartyAPIResponse(t *testing.T) {
 	if err == nil {
 		t.Error("There is an error")
 	}
+}
+
+func TestPolicyActionEnum(t *testing.T) {
+	assert.Equal(t, "None", None.String())
+	assert.Equal(t, "Warning", Warning.String())
+	assert.Equal(t, "Failure", Failure.String())
 }
 
 func setupIQServer(t *testing.T) (server *Server) {

--- a/iq/iq_test.go
+++ b/iq/iq_test.go
@@ -178,13 +178,31 @@ func Test_populateAbsoluteURL(t *testing.T) {
 	iq.Options.Server = "http://sillyplace.com:8090/"
 	statusURLResp.ReportHTMLURL = "/myReport"
 	statusURLResp.populateAbsoluteURL(iq.Options.Server)
-	assert.Equal(t, "http://sillyplace.com:8090//myReport", statusURLResp.AbsoluteReportHTMLURL)
+	assert.Equal(t, "http://sillyplace.com:8090/myReport", statusURLResp.AbsoluteReportHTMLURL)
 
 	// no slashes anywhere
 	iq.Options.Server = "http://sillyplace.com:8090"
 	statusURLResp.ReportHTMLURL = "myReport"
 	statusURLResp.populateAbsoluteURL(iq.Options.Server)
 	assert.Equal(t, "http://sillyplace.com:8090/myReport", statusURLResp.AbsoluteReportHTMLURL)
+
+	// absolute report url (the way it looks prior to iq 104+)
+	iq.Options.Server = "http://sillyplace.com:8090"
+	statusURLResp.ReportHTMLURL = "http://sillyplace.com:8090/myReport"
+	statusURLResp.populateAbsoluteURL(iq.Options.Server)
+	assert.Equal(t, "http://sillyplace.com:8090/myReport", statusURLResp.AbsoluteReportHTMLURL)
+
+	// oh the emptiness
+	iq.Options.Server = ""
+	statusURLResp.ReportHTMLURL = ""
+	statusURLResp.populateAbsoluteURL(iq.Options.Server)
+	assert.Equal(t, "/", statusURLResp.AbsoluteReportHTMLURL)
+
+	// parent directory weirdness
+	iq.Options.Server = "http://sillyplace.com:8090/./../"
+	statusURLResp.ReportHTMLURL = "/../myReport"
+	statusURLResp.populateAbsoluteURL(iq.Options.Server)
+	assert.Equal(t, "http://sillyplace.com:8090/./../../myReport", statusURLResp.AbsoluteReportHTMLURL)
 }
 
 func TestAuditPackages(t *testing.T) {

--- a/iq/iq_test.go
+++ b/iq/iq_test.go
@@ -74,6 +74,15 @@ const pollingResultRelative = `{
 	"isError": false
 }`
 
+//const pollingResultNotReady = `{
+//	"policyAction": "None",
+//	"reportHtmlUrl": "ui/links/application/test-app/report/95c4c14e",
+//	"reportPdfUrl": "ui/links/application/test-app/report/95c4c14e/pdf",
+//	"reportDataUrl": "api/v2/applications/test-app/reports/95c4c14e/raw",
+//	"embeddableReportHtmlUrl": "ui/links/application/test-app/report/95c4c14e/embeddable",
+//	"isError": false
+//}`
+
 func setupIqOptions() (options Options) {
 	options.Application = "testapp"
 	options.Server = "http://sillyplace.com:8090"
@@ -136,6 +145,25 @@ func Test_audit_WithStatusUnmarshalError(t *testing.T) {
 	assert.True(t, strings.Contains(err.Error(), "Could not unmarshal response from IQ server"))
 	assert.Equal(t, StatusURLResult{}, result)
 }
+
+//func Test_audit_WithLoop(t *testing.T) {
+//	httpmock.Activate()
+//	defer httpmock.DeactivateAndReset()
+//
+//	httpmock.RegisterResponder("POST", "http://sillyplace.com:8090/api/v2/scan/applications/4bb67dcfc86344e3a483832f8c496419/sources/nancy?stageId=develop",
+//		httpmock.NewStringResponder(202, thirdPartyAPIResultJSON))
+//
+//	httpmock.RegisterResponder("GET", "http://sillyplace.com:8090/api/v2/scan/applications/4bb67dcfc86344e3a483832f8c496419/status/9cee2b6366fc4d328edc318eae46b2cb",
+//		httpmock.NewStringResponder(202, ""))
+//
+//	httpmock.RegisterResponder("GET", "http://sillyplace.com:8090/api/v2/scan/applications/4bb67dcfc86344e3a483832f8c496419/status/9cee2b6366fc4d328edc318eae46b2cb",
+//		httpmock.NewStringResponder(200, pollingResult))
+//
+//	iq := setupIQServer(t)
+//	result, err := iq.audit("", "4bb67dcfc86344e3a483832f8c496419")
+//	assert.Nil(t, err)
+//	assert.Equal(t, StatusURLResult{PolicyAction: "None"}, result)
+//}
 
 func Test_populateAbsoluteURL(t *testing.T) {
 	iq := setupIQServer(t)

--- a/iq/iq_test.go
+++ b/iq/iq_test.go
@@ -74,15 +74,6 @@ const pollingResultRelative = `{
 	"isError": false
 }`
 
-//const pollingResultNotReady = `{
-//	"policyAction": "None",
-//	"reportHtmlUrl": "ui/links/application/test-app/report/95c4c14e",
-//	"reportPdfUrl": "ui/links/application/test-app/report/95c4c14e/pdf",
-//	"reportDataUrl": "api/v2/applications/test-app/reports/95c4c14e/raw",
-//	"embeddableReportHtmlUrl": "ui/links/application/test-app/report/95c4c14e/embeddable",
-//	"isError": false
-//}`
-
 func setupIqOptions() (options Options) {
 	options.Application = "testapp"
 	options.Server = "http://sillyplace.com:8090"

--- a/iq/iq_test.go
+++ b/iq/iq_test.go
@@ -242,7 +242,7 @@ func TestAuditPackages(t *testing.T) {
 
 	result, _ := iq.AuditPackages(purls)
 
-	statusExpected := StatusURLResult{PolicyAction: None.String(),
+	statusExpected := StatusURLResult{PolicyAction: None,
 		ReportHTMLURL:         "http://sillyplace.com:8090/ui/links/application/test-app/report/95c4c14e",
 		AbsoluteReportHTMLURL: "http://sillyplace.com:8090/ui/links/application/test-app/report/95c4c14e",
 	}
@@ -287,7 +287,7 @@ func TestAuditPackagesRelativeResult(t *testing.T) {
 
 	result, _ := iq.AuditPackages(purls)
 
-	statusExpected := StatusURLResult{PolicyAction: None.String(),
+	statusExpected := StatusURLResult{PolicyAction: None,
 		ReportHTMLURL:         "ui/links/application/test-app/report/95c4c14e",
 		AbsoluteReportHTMLURL: "http://sillyplace.com:8090/ui/links/application/test-app/report/95c4c14e",
 	}
@@ -324,7 +324,7 @@ func TestAuditPackagesWithSBOM(t *testing.T) {
 
 	result, _ := iq.AuditWithSbom(sbom)
 
-	statusExpected := StatusURLResult{PolicyAction: None.String(),
+	statusExpected := StatusURLResult{PolicyAction: None,
 		ReportHTMLURL:         "http://sillyplace.com:8090/ui/links/application/test-app/report/95c4c14e",
 		AbsoluteReportHTMLURL: "http://sillyplace.com:8090/ui/links/application/test-app/report/95c4c14e",
 	}
@@ -548,9 +548,9 @@ func TestAuditPackagesIqUpButBadThirdPartyAPIResponse(t *testing.T) {
 }
 
 func TestPolicyActionEnum(t *testing.T) {
-	assert.Equal(t, "None", None.String())
-	assert.Equal(t, "Warning", Warning.String())
-	assert.Equal(t, "Failure", Failure.String())
+	assert.Equal(t, "None", None)
+	assert.Equal(t, "Warning", Warning)
+	assert.Equal(t, "Failure", Failure)
 }
 
 func setupIQServer(t *testing.T) (server *Server) {

--- a/iq/iq_test.go
+++ b/iq/iq_test.go
@@ -242,7 +242,7 @@ func TestAuditPackages(t *testing.T) {
 
 	result, _ := iq.AuditPackages(purls)
 
-	statusExpected := StatusURLResult{PolicyAction: None,
+	statusExpected := StatusURLResult{PolicyAction: PolicyActionNone,
 		ReportHTMLURL:         "http://sillyplace.com:8090/ui/links/application/test-app/report/95c4c14e",
 		AbsoluteReportHTMLURL: "http://sillyplace.com:8090/ui/links/application/test-app/report/95c4c14e",
 	}
@@ -287,7 +287,7 @@ func TestAuditPackagesRelativeResult(t *testing.T) {
 
 	result, _ := iq.AuditPackages(purls)
 
-	statusExpected := StatusURLResult{PolicyAction: None,
+	statusExpected := StatusURLResult{PolicyAction: PolicyActionNone,
 		ReportHTMLURL:         "ui/links/application/test-app/report/95c4c14e",
 		AbsoluteReportHTMLURL: "http://sillyplace.com:8090/ui/links/application/test-app/report/95c4c14e",
 	}
@@ -324,7 +324,7 @@ func TestAuditPackagesWithSBOM(t *testing.T) {
 
 	result, _ := iq.AuditWithSbom(sbom)
 
-	statusExpected := StatusURLResult{PolicyAction: None,
+	statusExpected := StatusURLResult{PolicyAction: PolicyActionNone,
 		ReportHTMLURL:         "http://sillyplace.com:8090/ui/links/application/test-app/report/95c4c14e",
 		AbsoluteReportHTMLURL: "http://sillyplace.com:8090/ui/links/application/test-app/report/95c4c14e",
 	}
@@ -548,9 +548,9 @@ func TestAuditPackagesIqUpButBadThirdPartyAPIResponse(t *testing.T) {
 }
 
 func TestPolicyActionEnum(t *testing.T) {
-	assert.Equal(t, "None", None)
-	assert.Equal(t, "Warning", Warning)
-	assert.Equal(t, "Failure", Failure)
+	assert.Equal(t, "None", PolicyActionNone)
+	assert.Equal(t, "Warning", PolicyActionWarning)
+	assert.Equal(t, "Failure", PolicyActionFailure)
 }
 
 func setupIQServer(t *testing.T) (server *Server) {

--- a/iq/iq_test.go
+++ b/iq/iq_test.go
@@ -64,6 +64,16 @@ const pollingResult = `{
 	"isError": false
 }`
 
+// since IQ 104
+const pollingResultRelative = `{
+	"policyAction": "None",
+	"reportHtmlUrl": "ui/links/application/test-app/report/95c4c14e",
+	"reportPdfUrl": "ui/links/application/test-app/report/95c4c14e/pdf",
+	"reportDataUrl": "api/v2/applications/test-app/reports/95c4c14e/raw",
+	"embeddableReportHtmlUrl": "ui/links/application/test-app/report/95c4c14e/embeddable",
+	"isError": false
+}`
+
 func setupIqOptions() (options Options) {
 	options.Application = "testapp"
 	options.Server = "http://sillyplace.com:8090"
@@ -110,6 +120,54 @@ func TestNewRequiredAndModifiedOptions(t *testing.T) {
 	assert.Equal(t, server.Options.Server, "myServer")
 }
 
+func Test_audit_WithStatusUnmarshalError(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("POST", "http://sillyplace.com:8090/api/v2/scan/applications/4bb67dcfc86344e3a483832f8c496419/sources/nancy?stageId=develop",
+		httpmock.NewStringResponder(202, thirdPartyAPIResultJSON))
+
+	httpmock.RegisterResponder("GET", "http://sillyplace.com:8090/api/v2/scan/applications/4bb67dcfc86344e3a483832f8c496419/status/9cee2b6366fc4d328edc318eae46b2cb",
+		httpmock.NewStringResponder(200, pollingResult+"bogusResponseData"))
+
+	iq := setupIQServer(t)
+	result, err := iq.audit("", "4bb67dcfc86344e3a483832f8c496419")
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "Could not unmarshal response from IQ server"))
+	assert.Equal(t, StatusURLResult{}, result)
+}
+
+func Test_populateAbsoluteURL(t *testing.T) {
+	iq := setupIQServer(t)
+
+	// defaults, just for completeness
+	iq.populateAbsoluteURL()
+	assert.Equal(t, "http://sillyplace.com:8090/", statusURLResp.AbsoluteReportHTMLURL)
+
+	// slash prefix on relative url
+	statusURLResp.ReportHTMLURL = "/myReport"
+	iq.populateAbsoluteURL()
+	assert.Equal(t, "http://sillyplace.com:8090/myReport", statusURLResp.AbsoluteReportHTMLURL)
+
+	// slash suffix on server url
+	iq.Options.Server = "http://sillyplace.com:8090/"
+	statusURLResp.ReportHTMLURL = "myReport"
+	iq.populateAbsoluteURL()
+	assert.Equal(t, "http://sillyplace.com:8090/myReport", statusURLResp.AbsoluteReportHTMLURL)
+
+	// slashes everywhere - we don't avoid double slash-ery
+	iq.Options.Server = "http://sillyplace.com:8090/"
+	statusURLResp.ReportHTMLURL = "/myReport"
+	iq.populateAbsoluteURL()
+	assert.Equal(t, "http://sillyplace.com:8090//myReport", statusURLResp.AbsoluteReportHTMLURL)
+
+	// no slashes anywhere
+	iq.Options.Server = "http://sillyplace.com:8090"
+	statusURLResp.ReportHTMLURL = "myReport"
+	iq.populateAbsoluteURL()
+	assert.Equal(t, "http://sillyplace.com:8090/myReport", statusURLResp.AbsoluteReportHTMLURL)
+}
+
 func TestAuditPackages(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
@@ -147,9 +205,57 @@ func TestAuditPackages(t *testing.T) {
 
 	result, _ := iq.AuditPackages(purls)
 
-	statusExpected := StatusURLResult{PolicyAction: "None", ReportHTMLURL: "http://sillyplace.com:8090/ui/links/application/test-app/report/95c4c14e", IsError: false}
+	statusExpected := StatusURLResult{PolicyAction: "None",
+		ReportHTMLURL:         "http://sillyplace.com:8090/ui/links/application/test-app/report/95c4c14e",
+		AbsoluteReportHTMLURL: "http://sillyplace.com:8090/ui/links/application/test-app/report/95c4c14e",
+	}
 
-	assert.Equal(t, result, statusExpected)
+	assert.Equal(t, statusExpected, result)
+}
+
+func TestAuditPackagesRelativeResult(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	jsonCoordinates, _ := json.Marshal([]types.Coordinate{
+		{
+			Coordinates:     "pkg:golang/golang.org/x/crypto@v0.0.0-20190308221718-c2843e01d9a2",
+			Reference:       "https://ossindex.sonatype.org/component/pkg:golang/golang.org/x/crypto@v0.0.0-20190308221718-c2843e01d9a2",
+			Vulnerabilities: []types.Vulnerability{},
+		},
+		{
+			Coordinates:     "pkg:golang/github.com/go-yaml/yaml@v2.2.2",
+			Reference:       "https://ossindex.sonatype.org/component/pkg:golang/github.com/go-yaml/yaml@v2.2.2",
+			Vulnerabilities: []types.Vulnerability{},
+		},
+	})
+
+	httpmock.RegisterResponder("POST", "https://ossindex.sonatype.org/api/v3/component-report",
+		httpmock.NewStringResponder(200, string(jsonCoordinates)))
+
+	httpmock.RegisterResponder("GET", "http://sillyplace.com:8090/api/v2/applications?publicId=testapp",
+		httpmock.NewStringResponder(200, applicationsResponse))
+
+	httpmock.RegisterResponder("POST", "http://sillyplace.com:8090/api/v2/scan/applications/4bb67dcfc86344e3a483832f8c496419/sources/nancy?stageId=develop",
+		httpmock.NewStringResponder(202, thirdPartyAPIResultJSON))
+
+	httpmock.RegisterResponder("GET", "http://sillyplace.com:8090/api/v2/scan/applications/4bb67dcfc86344e3a483832f8c496419/status/9cee2b6366fc4d328edc318eae46b2cb",
+		httpmock.NewStringResponder(200, pollingResultRelative))
+
+	var purls []string
+	purls = append(purls, "pkg:golang/github.com/go-yaml/yaml@v2.2.2")
+	purls = append(purls, "pkg:golang/golang.org/x/crypto@v0.0.0-20190308221718-c2843e01d9a2")
+
+	iq := setupIQServer(t)
+
+	result, _ := iq.AuditPackages(purls)
+
+	statusExpected := StatusURLResult{PolicyAction: "None",
+		ReportHTMLURL:         "ui/links/application/test-app/report/95c4c14e",
+		AbsoluteReportHTMLURL: "http://sillyplace.com:8090/ui/links/application/test-app/report/95c4c14e",
+	}
+
+	assert.Equal(t, statusExpected, result)
 }
 
 func TestAuditPackagesWithSBOM(t *testing.T) {
@@ -181,7 +287,10 @@ func TestAuditPackagesWithSBOM(t *testing.T) {
 
 	result, _ := iq.AuditWithSbom(sbom)
 
-	statusExpected := StatusURLResult{PolicyAction: "None", ReportHTMLURL: "http://sillyplace.com:8090/ui/links/application/test-app/report/95c4c14e", IsError: false}
+	statusExpected := StatusURLResult{PolicyAction: "None",
+		ReportHTMLURL:         "http://sillyplace.com:8090/ui/links/application/test-app/report/95c4c14e",
+		AbsoluteReportHTMLURL: "http://sillyplace.com:8090/ui/links/application/test-app/report/95c4c14e",
+	}
 
 	assert.Equal(t, result, statusExpected)
 }

--- a/iq/iq_test.go
+++ b/iq/iq_test.go
@@ -224,7 +224,7 @@ func TestAuditPackages(t *testing.T) {
 
 	result, _ := iq.AuditPackages(purls)
 
-	statusExpected := StatusURLResult{PolicyAction: "None",
+	statusExpected := StatusURLResult{PolicyAction: PolicyActionNone,
 		ReportHTMLURL:         "http://sillyplace.com:8090/ui/links/application/test-app/report/95c4c14e",
 		AbsoluteReportHTMLURL: "http://sillyplace.com:8090/ui/links/application/test-app/report/95c4c14e",
 	}
@@ -269,7 +269,7 @@ func TestAuditPackagesRelativeResult(t *testing.T) {
 
 	result, _ := iq.AuditPackages(purls)
 
-	statusExpected := StatusURLResult{PolicyAction: "None",
+	statusExpected := StatusURLResult{PolicyAction: PolicyActionNone,
 		ReportHTMLURL:         "ui/links/application/test-app/report/95c4c14e",
 		AbsoluteReportHTMLURL: "http://sillyplace.com:8090/ui/links/application/test-app/report/95c4c14e",
 	}
@@ -306,7 +306,7 @@ func TestAuditPackagesWithSBOM(t *testing.T) {
 
 	result, _ := iq.AuditWithSbom(sbom)
 
-	statusExpected := StatusURLResult{PolicyAction: "None",
+	statusExpected := StatusURLResult{PolicyAction: PolicyActionNone,
 		ReportHTMLURL:         "http://sillyplace.com:8090/ui/links/application/test-app/report/95c4c14e",
 		AbsoluteReportHTMLURL: "http://sillyplace.com:8090/ui/links/application/test-app/report/95c4c14e",
 	}


### PR DESCRIPTION
Add a new field to carry a full (non-relative) report url. 

As of IQ 104, the report urls returned in the old field are relative urls. This PR adds a new field populated with an absolute url for viewing the report.

Also addresses some issues discovered with error handling on the go channel.

NOTE to self: replace PolicyAction consts with iota. see: https://yourbasic.org/golang/iota/