### PR TITLE
add godoc runnable examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Go Sonatypes
 
 <a href="https://circleci.com/gh/sonatype-nexus-community/go-sona-types"><img src="https://circleci.com/gh/sonatype-nexus-community/go-sona-types.svg?style=shield" alt="Circle CI Build Status"></img></a>
+[![Go Reference](https://pkg.go.dev/badge/github.com/sonatype-nexus-community/go-sona-types.svg)](https://pkg.go.dev/github.com/sonatype-nexus-community/go-sona-types)
 
 This project is a nice lil set of libraries that we created for working with:
 

--- a/configuration/set.go
+++ b/configuration/set.go
@@ -32,8 +32,10 @@ import (
 //goland:noinspection GoUnusedConst
 const ConfigTypeYaml = "yaml"
 
-// these consts must match their associated yaml tag below. for use where tag name matters, like viper
+// must match OSSIndexConfig.Username yaml tag. for use where tag name matters, like viper
 const ViperKeyUsername = "ossi.Username"
+
+// must match OSSIndexConfig.Token yaml tag. for use where tag name matters, like viper
 const ViperKeyToken = "ossi.Token"
 
 // OSSIndexConfig is a struct for holding OSS Index Configuration, and for writing it to yaml
@@ -42,13 +44,18 @@ type OSSIndexConfig struct {
 	Token    string `yaml:"Token"`
 }
 
+// Used when writing/reading OSS Index config to/from yaml files
 type ConfMarshallOssi struct {
 	Ossi OSSIndexConfig
 }
 
-// these consts must match their associated yaml tag below. for use where tag name matters, like viper
+// must match IQConfig.IQServer yaml tag. for use where tag name matters, like viper
 const ViperKeyIQServer = "iq.Server"
+
+// must match IQConfig.IQUsername yaml tag. for use where tag name matters, like viper
 const ViperKeyIQUsername = "iq.Username"
+
+// must match IQConfig.IQToken yaml tag. for use where tag name matters, like viper
 const ViperKeyIQToken = "iq.Token"
 
 // IQConfig is a struct for holding IQ Configuration, and for writing it to yaml
@@ -58,6 +65,7 @@ type IQConfig struct {
 	IQToken    string `yaml:"Token"`
 }
 
+// Used when writing/reading IQ Server config to/from yaml files
 type ConfMarshallIq struct {
 	Iq IQConfig
 }

--- a/configuration/set_test.go
+++ b/configuration/set_test.go
@@ -45,7 +45,7 @@ func ExampleConfMarshallOssi() {
 	if err != nil {
 		fmt.Println(err.Error())
 	}
-	// The yaml config file on disk should match the output printed below.
+	// The yaml config file content on disk should match the output printed below.
 	fmt.Printf("%s", b)
 	// Output:
 	// ossi:
@@ -65,7 +65,7 @@ func ExampleConfMarshallIq() {
 	if err != nil {
 		fmt.Println(err.Error())
 	}
-	// The yaml config file on disk should match the output printed below.
+	// The yaml config file content on disk should match the output printed below.
 	fmt.Printf("%s", b)
 	// Output:
 	// iq:

--- a/configuration/set_test.go
+++ b/configuration/set_test.go
@@ -16,6 +16,7 @@ package configuration
 
 import (
 	"bytes"
+	"fmt"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/sonatype-nexus-community/go-sona-types/internal"
 	"github.com/stretchr/testify/assert"
@@ -31,6 +32,46 @@ func setup(t *testing.T) (configSet *ConfigSet) {
 	assert.Nil(t, err)
 	configSet.HomeDir = "/tmp"
 	return
+}
+
+func ExampleConfMarshallOssi() {
+	config := ConfMarshallOssi{
+		Ossi: OSSIndexConfig{
+			Username: "ossiUser@email.com",
+			Token:    "ossiToken",
+		},
+	}
+	b, err := yaml.Marshal(config)
+	if err != nil {
+		fmt.Println(err.Error())
+	}
+	// The yaml config file on disk should match the output printed below.
+	fmt.Printf("%s", b)
+	// Output:
+	// ossi:
+	//   Username: ossiUser@email.com
+	//   Token: ossiToken
+}
+
+func ExampleConfMarshallIq() {
+	config := ConfMarshallIq{
+		Iq: IQConfig{
+			IQUsername: "iqUserName",
+			IQToken:    "iqPassword",
+			IQServer:   "http://myIqServer",
+		},
+	}
+	b, err := yaml.Marshal(config)
+	if err != nil {
+		fmt.Println(err.Error())
+	}
+	// The yaml config file on disk should match the output printed below.
+	fmt.Printf("%s", b)
+	// Output:
+	// iq:
+	//   Server: http://myIqServer
+	//   Username: iqUserName
+	//   Token: iqPassword
 }
 
 func TestGetConfigFromCommandLineLoggerNil(t *testing.T) {


### PR DESCRIPTION
fun with godoc. Example `Output` section shows how the config.yaml file content is formatted.