### PR TITLE
Return a map[string]types.Coordinate from OSS Index

### DIFF
--- a/ossindex/ossindex.go
+++ b/ossindex/ossindex.go
@@ -81,6 +81,26 @@ func Default(logger *logrus.Logger) *Server {
 }
 
 // AuditPackages will given a slice of Package URLs run an OSS Index audit, and return the result
+func (o *Server) Audit(purls []string) (results map[string]types.Coordinate, err error) {
+	results = make(map[string]types.Coordinate)
+
+	coords, err := o.doAuditPackages(purls)
+	if err != nil {
+		return
+	}
+
+	if len(coords) > 0 {
+		for _, v := range coords {
+			results[v.Coordinates] = v
+		}
+
+		return
+	}
+
+	return
+}
+
+// AuditPackages will given a slice of Package URLs run an OSS Index audit, and return the result
 func (o *Server) AuditPackages(purls []string) ([]types.Coordinate, error) {
 	return o.doAuditPackages(purls)
 }

--- a/ossindex/ossindex.go
+++ b/ossindex/ossindex.go
@@ -80,7 +80,8 @@ func Default(logger *logrus.Logger) *Server {
 		})
 }
 
-// AuditPackages will given a slice of Package URLs run an OSS Index audit, and return the result
+// Audit will given a string slice of purls, run an OSS Index audit,
+// and return the result as a map of the coordinates, with the result under each key, or an error if applicable
 func (o *Server) Audit(purls []string) (results map[string]types.Coordinate, err error) {
 	results = make(map[string]types.Coordinate)
 


### PR DESCRIPTION
To greatly simplify working with OSS Index results upstream (and allowing us to do some more fun things), return `map[string]types.Coordinate`

Upstream this allows us to start using `O(1)` operations to find a coordinate, for example, if we know more about it aside from OSS Index (say if `go list -m -json -u all` gives us the Update info, which....it does :)) 

```
{
        "Path": "gopkg.in/yaml.v2",
        "Version": "v2.3.0",
        "Time": "2020-05-06T23:08:38Z",
        "Update": {
                "Path": "gopkg.in/yaml.v2",
                "Version": "v2.4.0",
                "Time": "2020-11-17T15:46:20Z"
        },
        "Dir": "/Users/darthhater/go/pkg/mod/gopkg.in/yaml.v2@v2.3.0",
        "GoMod": "/Users/darthhater/go/pkg/mod/cache/download/gopkg.in/yaml.v2/@v/v2.3.0.mod"
}
```

Upstream, if you know the path and version, you can construct a purl really easily, and match the OSS Index response to that purl with `O(1)` speed, rather than `O(n)`, since we have previously had to loop through a list to find things. This should allow us to start dramatically simplifying code (kills a lot of loops likely), and allow us to keep a lot more information in memory so we can help users out (by suggesting fixes, etc...)

So say you have an existing map with the key of the coordinate (purl) and resulting information locally (in Nancy this is basically the GoMod stuff shown above), you can start merging in the OSS Index results, and saying ok well, we know this one is vulnerable, but it also has an update! Let's go check if that is also vulnerable? Ok it isn't, lemme update this map right quick and mark it as good, and since I likely still know it's a `go mod` dep, why don't I also write a `replace` block for the user so they can add it to their project!

This should dramatically simplify some of the Audit functionality, as well!