### PR TITLE
Allow for base path of cache to be configured

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.14
+      - image: circleci/golang:1.15
         environment:
           GO111MODULE: "on"
           TEST_RESULTS: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.15
+      - image: circleci/golang:1.16
         environment:
           GO111MODULE: "on"
           TEST_RESULTS: /tmp/test-results

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ logger, _ := logrus.NewNullLogger()
 ossi := ossindex.Default(logger)
 
 // Obtains a pointer to a Server struct, with options you set
-ossi = ossindex.New(loggger, types.Options{Username: "username", Token: "token"})
+ossi = ossindex.New(loggger, types.Options{Username: "username", Token: "token", DBCachePath: "/tmp"})
 
 // Audits a slice of purls, returns results or an error
 results, err := ossi.AuditPackages([]string{"a", "list", "of", "purls"})

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A lot of our projects were starting to depend heavily on `nancy`, and it was slo
 
 ## Development
 
-You'll need Go 1.14, and that's about it!
+You'll need Go 1.16, and that's about it!
 
 Everything (tests, lint, etc...) can be run with `make` locally.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sonatype-nexus-community/go-sona-types
 
-go 1.14
+go 1.16
 
 require (
 	github.com/beevik/etree v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,7 @@ github.com/jarcoal/httpmock v1.0.5 h1:cHtVEcTxRSX4J0je7mWPfc9BpDpqzXSJ5HbymZmyHc
 github.com/jarcoal/httpmock v1.0.5/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/kr/pty v1.1.1 h1:VkoXIwSboBpnk99O/KFauAEILuNHv5DVFKZMBN/gUgw=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -22,6 +23,7 @@ github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXY
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=

--- a/go.sum
+++ b/go.sum
@@ -34,7 +34,6 @@ gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8X
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/go-playground/assert.v1 v1.2.1 h1:xoYuJVE7KT85PYWrN730RguIQO0ePzVRfFMXadIrXTM=
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/ossindex/internal/cache/cache.go
+++ b/ossindex/internal/cache/cache.go
@@ -40,6 +40,8 @@ type Cache struct {
 
 // Options is a struct with values necessary to run the cache package
 type Options struct {
+	// Base path for DB
+	DBCachePath string
 	// DBDirName is the directory that will be created or used for the cache DB, defaults to nancy
 	DBDirName string
 	// DBName is the actual name of the cache database on disk
@@ -65,11 +67,16 @@ func New(logger *logrus.Logger, options Options) *Cache {
 }
 
 func (c *Cache) getDatabasePath() (dbDir string, err error) {
+	// Allow someone to set a base path for a cache
+	if c.Options.DBCachePath != "" {
+		return path.Join(types.GetOssIndexDirectory(c.Options.DBCachePath), c.Options.DBDirName, c.Options.DBName), err
+	}
+
 	usr, err := user.Current()
 	if err != nil {
 		return "", &types.OSSIndexError{
 			Err:     err,
-			Message: "Error getting user home",
+			Message: "Error getting user DB path",
 		}
 	}
 
@@ -88,7 +95,7 @@ func (c *Cache) RemoveCache() error {
 	if err != nil {
 		return &types.OSSIndexError{
 			Err:     err,
-			Message: "Error getting user home",
+			Message: "Error getting user DB path",
 		}
 	}
 	err = pudge.DeleteFile(dbDir)
@@ -121,7 +128,7 @@ func (c *Cache) Insert(coordinates []types.Coordinate) (err error) {
 		if err != nil {
 			return &types.OSSIndexError{
 				Err:     err,
-				Message: "Error getting user home",
+				Message: "Error getting user DB path",
 			}
 		}
 
@@ -206,7 +213,7 @@ func (c *Cache) deleteKey(key string) error {
 	if err != nil {
 		return &types.OSSIndexError{
 			Err:     err,
-			Message: "Error getting user home",
+			Message: "Error getting user DB path",
 		}
 	}
 
@@ -222,7 +229,7 @@ func (c *Cache) getKeyAndHydrate(key string, item *DBValue) error {
 	if err != nil {
 		return &types.OSSIndexError{
 			Err:     err,
-			Message: "Error getting user home",
+			Message: "Error getting user DB path",
 		}
 	}
 

--- a/ossindex/ossindex.go
+++ b/ossindex/ossindex.go
@@ -66,8 +66,9 @@ func New(logger *logrus.Logger, options types.Options) *Server {
 		Options: options,
 		agent:   ua,
 		dbCache: cache.New(logger, cache.Options{
-			DBName: options.DBCacheName,
-			TTL:    options.TTL,
+			DBCachePath: options.DBCachePath,
+			DBName:      options.DBCacheName,
+			TTL:         options.TTL,
 		}),
 	}
 }

--- a/ossindex/types/types.go
+++ b/ossindex/types/types.go
@@ -69,6 +69,7 @@ type Options struct {
 	Tool        string
 	OSSIndexURL string
 	DBCacheName string
+	DBCachePath string
 	TTL         time.Time
 }
 


### PR DESCRIPTION
Based on https://github.com/sonatype-nexus-community/nancy/issues/216, allow for the OSS Index cache directory to be specified.

Adds a test setting this to `/tmp`, notes on such, and adds the setting to the example in the `README`.