### PR TITLE
Preserve error msg

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -7,7 +7,6 @@ github.com/jarcoal/httpmock v1.0.5 h1:cHtVEcTxRSX4J0je7mWPfc9BpDpqzXSJ5HbymZmyHc
 github.com/jarcoal/httpmock v1.0.5/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/kr/pty v1.1.1 h1:VkoXIwSboBpnk99O/KFauAEILuNHv5DVFKZMBN/gUgw=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -23,7 +22,6 @@ github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXY
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -396,7 +396,7 @@ func (i *Server) getInternalApplicationID(applicationID string) (string, error) 
 		"respBody":    respBody,
 	}).Error("Error communicating with Nexus IQ Server application endpoint")
 	return "", &ServerError{
-		Err: fmt.Errorf("Unable to communicate with Nexus IQ Server, status code returned is: %d, status: %s, body: %s",
+		Err: fmt.Errorf("unable to communicate with Nexus IQ Server, status code: %d, status: %s, body: %s",
 			resp.StatusCode, resp.Status, respBody),
 		Message: "Unable to communicate with Nexus IQ Server",
 	}

--- a/iq/iq.go
+++ b/iq/iq.go
@@ -380,7 +380,7 @@ func (i *Server) getInternalApplicationID(applicationID string) (string, error) 
 		}
 	}
 
-	// read body or response with error
+	// read body of response with error
 	//noinspection GoUnhandledErrorResult
 	defer resp.Body.Close()
 	var b []byte

--- a/iq/iq_test.go
+++ b/iq/iq_test.go
@@ -394,8 +394,9 @@ func TestAuditPackagesIqDownOrUnreachable(t *testing.T) {
 	httpmock.RegisterResponder("POST", "https://ossindex.sonatype.org/api/v3/component-report",
 		httpmock.NewStringResponder(200, string(jsonCoordinates)))
 
+	const errMsgFromIQ = "some error from IQ Server with helpful text"
 	httpmock.RegisterResponder("GET", "http://sillyplace.com:8090/api/v2/applications?publicId=testapp",
-		httpmock.NewBytesResponder(404, []byte("")))
+		httpmock.NewBytesResponder(404, []byte(errMsgFromIQ)))
 
 	var purls []string
 	purls = append(purls, "pkg:golang/github.com/go-yaml/yaml@v2.2.2")
@@ -407,6 +408,7 @@ func TestAuditPackagesIqDownOrUnreachable(t *testing.T) {
 	if err == nil {
 		t.Error("There is an error")
 	}
+	assert.Contains(t, err.Error(), errMsgFromIQ)
 }
 
 func TestAuditPackagesWithOssiError(t *testing.T) {


### PR DESCRIPTION
IQ will usually provide some helpful indication of how to solve errors, so we should surface the original response body in the error we return to clients.

Fixes #20 